### PR TITLE
Fix: Index out of range is thrown when no healthy endpoint is available

### DIFF
--- a/pkg/ads/api_tcp_client.go
+++ b/pkg/ads/api_tcp_client.go
@@ -346,7 +346,9 @@ func (c *client) newClientProperties(cl *envoy_config_cluster_v3.Cluster, route 
 	} else {
 		// if unsupported LB policy is configured return first healthy endpoint from the list
 		endpoints := endpoint.Filter(cla.GetEndpoints(), endpoint.HasSocketAddress(), endpoint.WithHealthyStatus())
-		endpointAddress = endpoint.GetAddress(endpoints[0])
+		if len(endpoints) > 0 {
+			endpointAddress = endpoint.GetAddress(endpoints[0])
+		}
 	}
 
 	metadata := map[string]interface{}{


### PR DESCRIPTION
Fix: When no healthy endpoint is available for a service the `GetHTTPClientPropertiesByHost` and `GetTCPClientPropertiesByHost` API calls panics `panic: runtime error: index out of range [0] with length 0`