### PR TITLE
kind: no need to explicitly set docker build arch

### DIFF
--- a/scripts/heimdall-image-build.sh
+++ b/scripts/heimdall-image-build.sh
@@ -21,5 +21,4 @@ IMAGE="${IMAGE:-heimdall:test}"
 
 DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker build "${DIRECTORY}/.." \
     -f "${DIRECTORY}/../experimental/heimdall/Dockerfile" \
-    -t "${IMAGE}" \
-    --platform linux/amd64
+    -t "${IMAGE}"


### PR DESCRIPTION
otherwise it fails to load on arm64