### PR TITLE
detect ports in address correctly (SplitHostPort bug)

### DIFF
--- a/pkg/ads/api_http_client.go
+++ b/pkg/ads/api_http_client.go
@@ -17,6 +17,7 @@ package ads
 import (
 	"context"
 	"net"
+	"net/url"
 	"reflect"
 	"strconv"
 
@@ -55,10 +56,12 @@ type httpClientPropertiesObservable struct {
 }
 
 func (c *client) GetHTTPClientPropertiesByHost(ctx context.Context, address string) (<-chan HTTPClientPropertiesResponse, error) {
-	host, port, err := net.SplitHostPort(address)
+	url, err := url.Parse("http://" + address)
 	if err != nil {
 		return nil, err
 	}
+	host := url.Hostname()
+	port := url.Port()
 	if host == "" {
 		return nil, errors.New("missing host or IP")
 	}

--- a/pkg/ads/api_listener_properties.go
+++ b/pkg/ads/api_listener_properties.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"reflect"
 	"strconv"
 
@@ -81,10 +82,12 @@ type listenerPropertiesObservable struct {
 // The caller must signal through the passed in Context when it's not interested in changes any more and the channel
 // can be closed. The channel is closed on ctx.Done()
 func (c *client) GetListenerProperties(ctx context.Context, address string) (<-chan ListenerPropertiesResponse, error) {
-	host, port, err := net.SplitHostPort(address)
+	url, err := url.Parse("tcp://" + address)
 	if err != nil {
 		return nil, err
 	}
+	host := url.Hostname()
+	port := url.Port()
 	if host == "" {
 		host = "0.0.0.0"
 	}

--- a/pkg/ads/api_tcp_client.go
+++ b/pkg/ads/api_tcp_client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"reflect"
 	"strconv"
 
@@ -99,10 +100,12 @@ type tcpClientPropertiesObservable struct {
 }
 
 func (c *client) GetTCPClientPropertiesByHost(ctx context.Context, address string) (<-chan ClientPropertiesResponse, error) {
-	host, port, err := net.SplitHostPort(address)
+	url, err := url.Parse("tcp://" + address)
 	if err != nil {
 		return nil, err
 	}
+	host := url.Hostname()
+	port := url.Port()
 	if host == "" {
 		return nil, errors.New("missing host")
 	}


### PR DESCRIPTION
Otherwise `http://echo.testing` doesn't get resolved, only `http://echo.testing:80`

See: https://github.com/golang/go/issues/16142