### PR TITLE
Delete Nametable entry that is not being subscribed anymore from internal state

### DIFF
--- a/pkg/ads/common.go
+++ b/pkg/ads/common.go
@@ -373,6 +373,7 @@ func (s *resourceCache) SetIstioResources(resourceType resource_v3.Type, resourc
 				}
 				// ignore resources we are not interested in case of explicit resource subscription
 				if !s.IsSubscribedFor(name) {
+					delete(s.resources, name)
 					continue
 				}
 


### PR DESCRIPTION
In case we are not interested in a Istio name table entry any more delete it from internal state.