### PR TITLE
ci: run ci on the main branch to heat the caches!

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
According to https://stackoverflow.com/questions/66563672/within-what-limits-github-actions-cache-work caching only works within the branch itself, of between a branch from main, but we never built the main branch before, so the caches were empty.