### PR TITLE
Optional test connection pod

### DIFF
--- a/experimental/heimdall/charts/heimdall/templates/tests/test-connection.yaml
+++ b/experimental/heimdall/charts/heimdall/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testConnection.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['{{ include "heimdall.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+{{- end }}

--- a/experimental/heimdall/charts/heimdall/values.yaml
+++ b/experimental/heimdall/charts/heimdall/values.yaml
@@ -77,6 +77,9 @@ tolerations: []
 
 affinity: {}
 
+testConnection:
+  enabled: true
+
 istio:
   controlPlane: icp-v115x
   controlPlaneNamespace: istio-system


### PR DESCRIPTION
## Description

Make the `test-connecion` pod optional behind a helm values switch.
## Type of Change

- [ ] Bug Fix
- [x] **_New Feature_**
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
