### PR TITLE
fix select timeout handling according to java doSelect

### DIFF
--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -110,7 +110,10 @@ func (s *Selector) Close() {
 }
 
 func (s *Selector) Select(timeoutMs int64) int {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	if timeoutMs != -1 {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
+	}
 	defer cancel()
 
 	go func() {
@@ -128,6 +131,10 @@ func (s *Selector) Select(timeoutMs int64) int {
 			return true
 		})
 	}()
+
+	if (timeoutMs == 0) && len(s.queue) == 0 {
+		return 0
+	}
 
 	select {
 	case c := <-s.queue:


### PR DESCRIPTION
The signature and docs of the Java `doSelect` from where we call the Go `Select` is the following:

```java
    /**
     * Selects the keys for channels that are ready for I/O operations.
     *
     * @param action  the action to perform, can be null
     * @param timeout timeout in milliseconds to wait, 0 to not wait, -1 to
     *                wait indefinitely
     */
    protected abstract int doSelect(Consumer<SelectionKey> action, long timeout)
        throws IOException;
```

So we should handle -1 and 0 accordingly.