### PR TITLE
fix NaspServerSocketChannel.accept

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocket.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocket.java
@@ -67,6 +67,9 @@ public class NaspServerSocket extends ServerSocket {
     public Socket accept() throws IOException {
         try {
             Connection conn = TCPListener.asyncAccept();
+            if (conn == null) {
+                return null;
+            }
             return new NaspSocket(selectorProvider, conn);
         } catch (Exception e) {
             throw new IOException("could not bound to nasp tcp listener");

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
@@ -6,6 +6,7 @@ import sun.nio.ch.SelectionKeyImpl;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.nio.channels.SelectionKey;
@@ -63,7 +64,11 @@ public class NaspServerSocketChannel extends ServerSocketChannel implements SelC
     }
 
     public SocketChannel accept() throws IOException {
-        return this.socket.accept().getChannel();
+        Socket client = socket.accept();
+        if (client == null) {
+            return null;
+        }
+        return client.getChannel();
     }
 
     @Override


### PR DESCRIPTION
According to ServerSocketChannel.java, the contract of accept is the following and we should handle this:

```java
    /**
     * ...
     *
     * @return  The socket channel for the new connection,
     *          or {@code null} if this channel is in non-blocking mode
     *          and no connection is available to be accepted
     */
    public abstract SocketChannel accept() throws IOException;
    ```
