### PR TITLE
nio: selectedKey performance improvement

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -20,6 +20,14 @@ import java.util.function.Consumer;
 
 class NaspSelector extends SelectorImpl {
 
+    static int getOperation(long selectedKey) {
+        return (int) (selectedKey >> 32);
+    }
+
+    static int getSelectedKeyId(long selectedKey) {
+        return (int) selectedKey;
+    }
+
     private final nasp.Selector selector = new nasp.Selector();
     private final Map<Integer, SelectionKeyImpl> selectionKeyTable = new HashMap<>();
 
@@ -32,12 +40,12 @@ class NaspSelector extends SelectorImpl {
         selector.select(timeout);
 
         int numKeysUpdated = 0;
-        nasp.SelectedKey selectedKey;
-        while ((selectedKey = selector.nextSelectedKey()) != null) {
-            SelectionKeyImpl selectionKey = selectionKeyTable.get(selectedKey.getSelectedKeyId());
+        long selectedKey;
+        while ((selectedKey = selector.nextSelectedKey()) != 0) {
+            SelectionKeyImpl selectionKey = selectionKeyTable.get(getSelectedKeyId(selectedKey));
             if (selectionKey != null) {
                 if (selectionKey.isValid()) {
-                    numKeysUpdated += processReadyEvents(selectedKey.getOperation(), selectionKey, action);
+                    numKeysUpdated += processReadyEvents(getOperation(selectedKey), selectionKey, action);
                 }
             }
         }
@@ -75,6 +83,7 @@ class NaspSelector extends SelectorImpl {
             int interestOps = ski.interestOps();
             if ((interestOps & SelectionKey.OP_READ) != 0) {
                 naspSockChan.getConnection().startAsyncRead(ski.hashCode(), selector);
+                naspSockChan.getConnection().startAsyncWrite(ski.hashCode(), selector);
             }
             if ((interestOps & SelectionKey.OP_WRITE) != 0) {
                 naspSockChan.getConnection().startAsyncWrite(ski.hashCode(), selector);

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -83,7 +83,6 @@ class NaspSelector extends SelectorImpl {
             int interestOps = ski.interestOps();
             if ((interestOps & SelectionKey.OP_READ) != 0) {
                 naspSockChan.getConnection().startAsyncRead(ski.hashCode(), selector);
-                naspSockChan.getConnection().startAsyncWrite(ski.hashCode(), selector);
             }
             if ((interestOps & SelectionKey.OP_WRITE) != 0) {
                 naspSockChan.getConnection().startAsyncWrite(ski.hashCode(), selector);

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -218,10 +218,10 @@ func (h *NaspIntegrationHandler) Bind(address string, port int) (*TCPListener, e
 		return nil, err
 	}
 
-	// listener, err = h.iih.GetTCPListener(listener)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	listener, err = h.iih.GetTCPListener(listener)
+	if err != nil {
+		return nil, err
+	}
 
 	return &TCPListener{
 		listener: listener,

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -42,12 +42,14 @@ import (
 
 const MAX_WRITE_BUFFERS = 64
 
+type ReadyOps uint32
+
 const (
-	OP_READ    = 1 << 0
-	OP_WRITE   = 1 << 2
-	OP_CONNECT = 1 << 3
-	OP_ACCEPT  = 1 << 4
-	OP_WAKEUP  = 1 << 5
+	OP_READ    ReadyOps = 1 << 0
+	OP_WRITE   ReadyOps = 1 << 2
+	OP_CONNECT ReadyOps = 1 << 3
+	OP_ACCEPT  ReadyOps = 1 << 4
+	OP_WAKEUP  ReadyOps = 1 << 5
 )
 
 var logger = klog.NewKlogr()
@@ -92,12 +94,12 @@ type Address struct {
 
 type SelectedKey uint64
 
-func NewSelectedKey(operation, id uint32) SelectedKey {
+func NewSelectedKey(operation ReadyOps, id uint32) SelectedKey {
 	return SelectedKey((uint64(operation) << 32) | uint64(id))
 }
 
-func (k SelectedKey) Operation() uint32 {
-	return uint32(k >> 32)
+func (k SelectedKey) Operation() ReadyOps {
+	return ReadyOps(k >> 32)
 }
 
 func (k SelectedKey) SelectedKeyId() uint32 {
@@ -218,10 +220,10 @@ func (h *NaspIntegrationHandler) Bind(address string, port int) (*TCPListener, e
 		return nil, err
 	}
 
-	listener, err = h.iih.GetTCPListener(listener)
-	if err != nil {
-		return nil, err
-	}
+	// listener, err = h.iih.GetTCPListener(listener)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return &TCPListener{
 		listener: listener,

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -220,10 +220,10 @@ func (h *NaspIntegrationHandler) Bind(address string, port int) (*TCPListener, e
 		return nil, err
 	}
 
-	// listener, err = h.iih.GetTCPListener(listener)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	listener, err = h.iih.GetTCPListener(listener)
+	if err != nil {
+		return nil, err
+	}
 
 	return &TCPListener{
 		listener: listener,

--- a/experimental/java/main_test.go
+++ b/experimental/java/main_test.go
@@ -1,0 +1,17 @@
+package nasp
+
+import (
+	"testing"
+)
+
+func TestSelectedKey(t *testing.T) {
+	sk := NewSelectedKey(OP_ACCEPT, 12345)
+
+	if sk.Operation() != OP_ACCEPT {
+		t.Fatalf("sk.Operation() -> %d != operation -> %d", sk.Operation(), OP_ACCEPT)
+	}
+
+	if sk.SelectedKeyId() != 12345 {
+		t.Fatalf("sk.SelectedKeyId() -> %d != selectedKeyId -> %d", sk.SelectedKeyId(), 12345)
+	}
+}

--- a/experimental/java/main_test.go
+++ b/experimental/java/main_test.go
@@ -23,7 +23,7 @@ import (
 func TestSelectedKey(t *testing.T) {
 	t.Parallel()
 
-	const operation uint32 = OP_ACCEPT
+	const operation ReadyOps = OP_ACCEPT
 	const selectedKeyId uint32 = 12345
 
 	sk := NewSelectedKey(operation, selectedKeyId)

--- a/experimental/java/main_test.go
+++ b/experimental/java/main_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 package nasp
 
 import (

--- a/experimental/java/main_test.go
+++ b/experimental/java/main_test.go
@@ -16,16 +16,18 @@ package nasp
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSelectedKey(t *testing.T) {
-	sk := NewSelectedKey(OP_ACCEPT, 12345)
+	t.Parallel()
 
-	if sk.Operation() != OP_ACCEPT {
-		t.Fatalf("sk.Operation() -> %d != operation -> %d", sk.Operation(), OP_ACCEPT)
-	}
+	const operation uint32 = OP_ACCEPT
+	const selectedKeyId uint32 = 12345
 
-	if sk.SelectedKeyId() != 12345 {
-		t.Fatalf("sk.SelectedKeyId() -> %d != selectedKeyId -> %d", sk.SelectedKeyId(), 12345)
-	}
+	sk := NewSelectedKey(operation, selectedKeyId)
+
+	assert.Equal(t, sk.Operation(), operation, "sk.Operation() != operation")
+	assert.Equal(t, sk.SelectedKeyId(), selectedKeyId, "sk.SelectedKeyId() != selectedKeyId")
 }


### PR DESCRIPTION
## Description

Instead of returning `SelectedKey objects`, to the underlying Java selector (which has to be reference counted for the Go side, and GC-d on the Java side as well) we can just return a plain long, which holds all the necessary information that the previous object/struct did, without any memory/cpu/lock contention penalties.

This causes a 2.2x speed improvement overall, according to a dummy wrk test.


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
