### PR TITLE
fix nio java auth after heimdall refactor

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -78,7 +78,7 @@ class NaspSelector extends SelectorImpl {
     @Override
     protected void setEventOps(SelectionKeyImpl ski) {
         if (ski.channel() instanceof NaspServerSocketChannel naspServerSockChan) {
-            naspServerSockChan.socket().getTCPListener().startAsyncAccept(ski.hashCode(), selector);
+            naspServerSockChan.socket().getNaspTcpListener().startAsyncAccept(ski.hashCode(), selector);
         } else if (ski.channel() instanceof NaspSocketChannel naspSockChan) {
             int interestOps = ski.interestOps();
             if ((interestOps & SelectionKey.OP_READ) != 0) {
@@ -89,9 +89,9 @@ class NaspSelector extends SelectorImpl {
             }
             if ((interestOps & SelectionKey.OP_CONNECT) != 0) {
                 //This could happen if we are servers not clients
-                if (naspSockChan.getTCPDialer() != null) {
+                if (naspSockChan.getNaspTcpDialer() != null) {
                     InetSocketAddress address = naspSockChan.getAddress();
-                    naspSockChan.getTCPDialer().startAsyncDial(ski.hashCode(), selector,
+                    naspSockChan.getNaspTcpDialer().startAsyncDial(ski.hashCode(), selector,
                             address.getHostString(), address.getPort());
                 }
             }

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
@@ -60,7 +60,7 @@ public class NaspServerSocketChannel extends ServerSocketChannel implements SelC
 
     @Override
     protected void implCloseSelectableChannel() throws IOException {
-        socket.getTCPListener().close();
+        socket.getNaspTcpListener().close();
     }
 
     public SocketChannel accept() throws IOException {
@@ -135,6 +135,6 @@ public class NaspServerSocketChannel extends ServerSocketChannel implements SelC
 
     @Override
     public void kill() throws IOException {
-        socket.getTCPListener().close();
+        socket.getNaspTcpListener().close();
     }
 }

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -199,6 +199,7 @@ func NewNaspIntegrationHandler(heimdallURL, authorizationToken string) (*NaspInt
 		UseTLS:              true,
 	}, logger)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -491,11 +492,13 @@ func NewTCPDialer(heimdallURL, authorizationToken string) (*TCPDialer, error) {
 		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
 	}, logger)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	dialer, err := iih.GetTCPDialer()
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -595,11 +598,13 @@ func NewHTTPTransport(heimdallURL, authorizationToken string) (*HTTPTransport, e
 		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
 	}, logger)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	transport, err := iih.GetHTTPTransport(http.DefaultTransport)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -609,7 +614,12 @@ func NewHTTPTransport(heimdallURL, authorizationToken string) (*HTTPTransport, e
 		Transport: transport,
 	}
 
-	return &HTTPTransport{iih: iih, client: client, ctx: ctx, cancel: cancel}, nil
+	return &HTTPTransport{
+		iih:    iih,
+		client: client,
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
 }
 
 func (t *HTTPTransport) Request(method, url, body string) (*HTTPResponse, error) {

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -192,14 +192,15 @@ func (s *Selector) NextSelectedKey() int64 {
 }
 
 func NewNaspIntegrationHandler(heimdallURL, authorizationToken string) (*NaspIntegrationHandler, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS: true,
+		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
+		UseTLS:              true,
 	}, logger)
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go iih.Run(ctx)
 
@@ -483,8 +484,11 @@ type TCPDialer struct {
 }
 
 func NewTCPDialer(heimdallURL, authorizationToken string) (*TCPDialer, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS: true,
+		UseTLS:              true,
+		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
 	}, logger)
 	if err != nil {
 		return nil, err
@@ -494,8 +498,6 @@ func NewTCPDialer(heimdallURL, authorizationToken string) (*TCPDialer, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go iih.Run(ctx)
 
@@ -586,8 +588,11 @@ type HTTPResponse struct {
 }
 
 func NewHTTPTransport(heimdallURL, authorizationToken string) (*HTTPTransport, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS: true,
+		UseTLS:              true,
+		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
 	}, logger)
 	if err != nil {
 		return nil, err
@@ -597,8 +602,6 @@ func NewHTTPTransport(heimdallURL, authorizationToken string) (*HTTPTransport, e
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
 
 	go iih.Run(ctx)
 


### PR DESCRIPTION
## Description

From now on you need a NASP_AUTH_TOKEN environment variable, in Kafka, IntelliJ, etc...:

You can grab one with:
```bash
export NASP_AUTH_TOKEN=$(kubectl -n external get secret -l nasp.k8s.cisco.com/workloadgroup=test-tcp -o jsonpath='{@.items[0].data.token}' | base64 -d)
```

This currently expires after one day.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
