### PR TITLE
Fix: write should return actual bytes count written to channel

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
@@ -155,19 +155,13 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
                 return 0;
             }
 
-            int writtenBytes = 0;
+            int srcBufPos = src.position();
             byte[] temp = new byte[rem];
             src.get(temp, 0, rem);
+            int writtenBytes = connection.asyncWrite(temp);
 
-            while (writtenBytes < rem) {
-                int n = connection.asyncWrite(temp);
-                writtenBytes += n;
-                if (writtenBytes < rem) {
-                    int remLength = rem - writtenBytes;
-                    byte[] remBytes = new byte[remLength];
-                    System.arraycopy(temp, n, remBytes, 0, remLength);
-                    temp = remBytes;
-                }
+            if (writtenBytes < rem) {
+                src.position(srcBufPos + writtenBytes);
             }
 
             return writtenBytes;


### PR DESCRIPTION
## Description
Fix: write should return actual bytes count written to channel and the buffer's position adjusted accordingly


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
