### PR TITLE
Fix: write operation should never return -1

### DIFF
--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -476,7 +476,7 @@ func (c *Connection) Close() {
 
 func (c *Connection) AsyncWrite(b []byte) (int32, error) {
 	if c.eofReceived() {
-		return -1, nil
+		return 0, nil
 	}
 
 	bCopy := make([]byte, len(b))


### PR DESCRIPTION
## Description

`write` operation should never return -1 according to the documentation.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

