### PR TITLE
Remove deregistered selection key from async ops

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -99,6 +99,7 @@ class NaspSelector extends SelectorImpl {
     @Override
     protected void implDereg(SelectionKeyImpl ski) throws IOException {
         selectionKeyTable.remove(ski.hashCode());
+        runningAsyncOps.remove(ski.hashCode());
     }
 
     @Override


### PR DESCRIPTION
## Description

Remove deregistered selection key from async ops
## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

