### PR TITLE
Enhance logging

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspLogSink.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspLogSink.java
@@ -2,10 +2,7 @@ package com.ciscoopen.app;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import nasp.Nasp;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.util.Iterator;

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -240,6 +240,21 @@ public class NaspSelectorProvider extends SelectorProviderImpl {
             throw new RuntimeException(e);
         }
 
+        long naspLogLevel = 0;
+        if (logger.isTraceEnabled()) {
+            naspLogLevel = 0;
+        } else if (logger.isDebugEnabled()) {
+            naspLogLevel = 1;
+        } else if (logger.isInfoEnabled()) {
+            naspLogLevel = 2;
+        } else if (logger.isWarnEnabled()) {
+            naspLogLevel = 3;
+        } else if (logger.isErrorEnabled()) {
+            naspLogLevel = 4;
+        }
+
+        Nasp.setup(naspLogLevel);
+
         executorService.scheduleAtFixedRate(() -> {
             byte[] logBatch = Nasp.nextLogBatchJSON(10);
             if (logBatch != null) {


### PR DESCRIPTION
## Description

Pass Java host's log level to Nasp library to initialize its internal logger with the correct log level to avoid passing too many unnecessary logs to Java host (e.g Nasp's internal logger is set to be more verbose level than the Java host's logger)

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

