### PR TITLE
Use endpoint metadata filter to match transport socket config

### DIFF
--- a/pkg/ads/api_listener_properties.go
+++ b/pkg/ads/api_listener_properties.go
@@ -220,13 +220,13 @@ func (c *client) getListenerProperties(input getListenerPropertiesInput) (Listen
 
 			metadata, err := listener.GetMetadata(lstnr)
 			if err != nil {
-				return nil, errors.WrapIf(err, "couldn't get lstnr metadata")
+				return nil, errors.WrapIf(err, "couldn't get listener metadata")
 			}
 
 			lp = &listenerProperties{
-				// if at least one of the filter chain uses TLS proto for matching than the lstnr support TLS communication
+				// if at least one of the filter chain uses TLS proto for matching than the listener support TLS communication
 				useTLS: tlsTransportProto,
-				// if there are filter chains for both TLS and raw_buffer proto than the lstnr is PERMISSIVE
+				// if there are filter chains for both TLS and raw_buffer proto than the listener is PERMISSIVE
 				permissive: tlsTransportProto && rawBufferTransProto,
 				// shows whether client certificate is required
 				requireClientCertificate: requireClientCertificate,

--- a/pkg/ads/api_listener_properties.go
+++ b/pkg/ads/api_listener_properties.go
@@ -218,7 +218,7 @@ func (c *client) getListenerProperties(input getListenerPropertiesInput) (Listen
 				}
 			}
 
-			metadata, err := listener.GetMetadata(lstnr)
+			metadata, err := listener.GetFilterMetadata(lstnr)
 			if err != nil {
 				return nil, errors.WrapIf(err, "couldn't get listener metadata")
 			}

--- a/pkg/ads/internal/endpoint/endpoint.go
+++ b/pkg/ads/internal/endpoint/endpoint.go
@@ -83,7 +83,10 @@ func GetAddress(ep *envoy_config_endpoint_v3.Endpoint) net.Addr {
 	}
 }
 
-func GetMetadata(cla *envoy_config_endpoint_v3.ClusterLoadAssignment, endpointAddress net.Addr) (map[string]interface{}, error) {
+// GetFilterMetadata returns the cluster load assignment (CLA) metadata stored under the 'metadata.typed_filter_metadata'
+// and 'metadata.filter_metadata' for the given endpoint address of the CLA.
+// If a key is present on both the one from 'metadata.typed_filter_metadata' will be taken into account.
+func GetFilterMetadata(cla *envoy_config_endpoint_v3.ClusterLoadAssignment, endpointAddress net.Addr) (map[string]interface{}, error) {
 	for _, localityLbEp := range cla.GetEndpoints() {
 		for _, lbEp := range localityLbEp.GetLbEndpoints() {
 			sockAddr := GetAddress(lbEp.GetEndpoint())
@@ -92,7 +95,7 @@ func GetMetadata(cla *envoy_config_endpoint_v3.ClusterLoadAssignment, endpointAd
 			}
 
 			if sockAddr.String() == endpointAddress.String() {
-				return util.GetUnifiedMetadata(lbEp.GetMetadata())
+				return util.GetUnifiedFilterMetadata(lbEp.GetMetadata())
 			}
 		}
 	}

--- a/pkg/ads/internal/listener/listener.go
+++ b/pkg/ads/internal/listener/listener.go
@@ -172,6 +172,9 @@ func GetRouteConfigName(listener *envoy_config_listener_v3.Listener) string {
 	return ""
 }
 
-func GetMetadata(listener *envoy_config_listener_v3.Listener) (map[string]interface{}, error) {
-	return util.GetUnifiedMetadata(listener.GetMetadata())
+// GetFilterMetadata returns the listener metadata stored under the 'metadata.typed_filter_metadata'
+// and 'metadata.filter_metadata' of the given listener.
+// If a key is present on both the one from 'metadata.typed_filter_metadata' will be taken into account.
+func GetFilterMetadata(listener *envoy_config_listener_v3.Listener) (map[string]interface{}, error) {
+	return util.GetUnifiedFilterMetadata(listener.GetMetadata())
 }

--- a/pkg/ads/internal/route/route.go
+++ b/pkg/ads/internal/route/route.go
@@ -128,6 +128,9 @@ func GetTargetClusterName(route *envoy_config_route_v3.Route, clustersStats *clu
 	return ""
 }
 
-func GetMetadata(route *envoy_config_route_v3.Route) (map[string]interface{}, error) {
-	return util.GetUnifiedMetadata(route.GetMetadata())
+// GetFilterMetadata returns the route configuration metadata stored under the 'metadata.typed_filter_metadata'
+// and 'metadata.filter_metadata' of the given route configuration.
+// If a key is present on both the one from 'metadata.typed_filter_metadata' will be taken into account.
+func GetFilterMetadata(route *envoy_config_route_v3.Route) (map[string]interface{}, error) {
+	return util.GetUnifiedFilterMetadata(route.GetMetadata())
 }

--- a/pkg/ads/internal/util/util.go
+++ b/pkg/ads/internal/util/util.go
@@ -175,7 +175,10 @@ func GetDownstreamTlsContext(ts *envoy_config_core_v3.TransportSocket) *auth.Dow
 	return nil
 }
 
-func GetUnifiedMetadata(md *envoy_config_core_v3.Metadata) (map[string]interface{}, error) {
+// GetUnifiedFilterMetadata returns the filter metadata stored under the 'metadata.typed_filter_metadata'
+// and 'metadata.filter_metadata' of the given metadat.
+// If a key is present on both the one from 'metadata.typed_filter_metadata' will be taken into account.
+func GetUnifiedFilterMetadata(md *envoy_config_core_v3.Metadata) (map[string]interface{}, error) {
 	rawMetadata := make(map[string]interface{})
 
 	for k, v := range md.GetTypedFilterMetadata() {


### PR DESCRIPTION
## Description

Use endpoint metadata filter to match transport socket config when determining tcp client properties.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
