### PR TITLE
support Istio handler enabled/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ To learn more about why we created Nasp, and where could it help, read our intro
 
 We use GitHub to track issues and accept contributions. If you'd like to raise an issue or open a pull request with changes, refer to our [contribution guide](./CONTRIBUTING.md).
 
-
 ## Getting started
 
 The easiest way to get started with Nasp is to import the library from Go code, set up a Nasp HTTP `transport`, and use that `transport` to send HTTP requests to an external server. Here's how to do it.
@@ -34,20 +33,16 @@ import (
 Then, create and start an `IstioIntegrationHandler`:
 
 ```go
-istioHandlerConfig := &istio.IstioIntegrationHandlerConfig {
-    MetricsAddress: ":16090",
-    UseTLS:         true,
-        IstioCAConfigGetter: func(e *environment.IstioEnvironment) (istio_ca.IstioCAClientConfig, error) {
-        return istio_ca.GetIstioCAClientConfig(clusterID, istioRevision)
-    },
-}
+istioHandlerConfig := &istio.DefaultIstioIntegrationHandlerConfig
 
 iih, err := istio.NewIstioIntegrationHandler(istioHandlerConfig, klog.TODO())
 if err != nil {
     panic(err)
 }
 
-iih.Run(ctx)
+if err := iih.Run(ctx); err != nil {
+    panic(err)
+}
 ```
 
 And finally, send an HTTP request through the Nasp transport layer:

--- a/components/bifrost/pkg/commands/server.go
+++ b/components/bifrost/pkg/commands/server.go
@@ -44,8 +44,8 @@ func NewServerCommand() *cobra.Command {
 			options := []server.ServerOption{server.ServerWithLogger(logger)}
 
 			if naspSupportEnabled {
-				istioConfig := istio.DefaultIstioIntegrationHandlerConfig
-				ih, err := istio.NewIstioIntegrationHandler(&istioConfig, logger)
+				istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+				ih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, logger)
 				if err != nil {
 					return errors.WrapIf(err, "could not instantiate NASP istio integration handler")
 				}

--- a/components/heimdall/pkg/webhooks/pod_mutator.go
+++ b/components/heimdall/pkg/webhooks/pod_mutator.go
@@ -260,6 +260,10 @@ func (m *PodMutator) setEnvs(pod *corev1.Pod, request admission.Request) {
 		}
 		container.Env = append(container.Env, []corev1.EnvVar{
 			{
+				Name:  "NASP_ENABLED",
+				Value: "true",
+			},
+			{
 				Name:  "NASP_TYPE",
 				Value: "sidecar",
 			},

--- a/examples/grpc/client/main.go
+++ b/examples/grpc/client/main.go
@@ -46,10 +46,10 @@ func main() {
 		panic(errors.New("NASP_AUTH_TOKEN env var must be specified."))
 	}
 
-	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1"),
-	}, klog.TODO())
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1")
+
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, klog.TODO())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -56,10 +56,10 @@ func main() {
 		panic(errors.New("NASP_AUTH_TOKEN env var must be specified."))
 	}
 
-	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1"),
-	}, klog.TODO())
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1")
+
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, klog.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -111,10 +111,8 @@ func main() {
 		panic(errors.New("NASP_AUTH_TOKEN env var must be specified."))
 	}
 
-	istioHandlerConfig := &istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1"),
-	}
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1")
 
 	if usePushGateway {
 		istioHandlerConfig.PushgatewayConfig = &istio.PushgatewayConfig{
@@ -123,7 +121,7 @@ func main() {
 		}
 	}
 
-	iih, err := istio.NewIstioIntegrationHandler(istioHandlerConfig, logger)
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/tcp/main.go
+++ b/examples/tcp/main.go
@@ -41,18 +41,16 @@ func init() {
 	flag.Parse()
 }
 
-func getIIH(ctx context.Context) (*istio.IstioIntegrationHandler, error) {
+func getIIH(ctx context.Context) (istio.IstioIntegrationHandler, error) {
 	authToken := os.Getenv("NASP_AUTH_TOKEN")
 	if authToken == "" {
 		panic(errors.New("NASP_AUTH_TOKEN env var must be specified."))
 	}
 
-	istioHandlerConfig := &istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1"),
-	}
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authToken, "v1")
 
-	iih, err := istio.NewIstioIntegrationHandler(istioHandlerConfig, klog.TODO())
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, klog.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -79,7 +79,7 @@ type TCPListener struct {
 }
 
 type naspIntegrationHandler struct {
-	iih    *istio.IstioIntegrationHandler
+	iih    istio.IstioIntegrationHandler
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -247,10 +247,9 @@ func (s *Selector) WakeUp() {
 func newNaspIntegrationHandler() *naspIntegrationHandler {
 	ctx, cancel := context.WithCancel(logr.NewContext(context.Background(), logger))
 
-	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		IstioCAConfigGetter: istio.IstioCAConfigGetterAuto,
-		UseTLS:              true,
-	}, logger)
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, logger)
 	if err != nil {
 		cancel()
 		panic(err)

--- a/experimental/mobile/main.go
+++ b/experimental/mobile/main.go
@@ -30,7 +30,7 @@ import (
 var logger = klog.NewKlogr()
 
 type HTTPTransport struct {
-	iih    *istio.IstioIntegrationHandler
+	iih    istio.IstioIntegrationHandler
 	client *http.Client
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -59,14 +59,14 @@ func NewHTTPTransport(heimdallURL, authorizationToken string) (*HTTPTransport, e
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	iih, err := istio.NewIstioIntegrationHandler(&istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
-		PushgatewayConfig: &istio.PushgatewayConfig{
-			Address:          "push-gw-prometheus-pushgateway.prometheus-pushgateway.svc.cluster.local:9091",
-			UseUniqueIDLabel: true,
-		},
-	}, logger)
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1")
+	istioHandlerConfig.PushgatewayConfig = &istio.PushgatewayConfig{
+		Address:          "push-gw-prometheus-pushgateway.prometheus-pushgateway.svc.cluster.local:9091",
+		UseUniqueIDLabel: true,
+	}
+
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/python/nasp/nasp.go
+++ b/experimental/python/nasp/nasp.go
@@ -141,13 +141,11 @@ func NewHTTPTransport(heimdallURLPtr, authorizationTokenPtr *C.char,
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	istioHandlerConfig := &istio.IstioIntegrationHandlerConfig{
-		UseTLS:              true,
-		IstioCAConfigGetter: istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1"),
-		PushgatewayConfig:   pgwConfig,
-	}
+	istioHandlerConfig := istio.DefaultIstioIntegrationHandlerConfig
+	istioHandlerConfig.IstioCAConfigGetter = istio.IstioCAConfigGetterHeimdall(ctx, heimdallURL, authorizationToken, "v1")
+	istioHandlerConfig.PushgatewayConfig = pgwConfig
 
-	iih, err := istio.NewIstioIntegrationHandler(istioHandlerConfig, logger)
+	iih, err := istio.NewIstioIntegrationHandler(&istioHandlerConfig, logger)
 
 	if err != nil {
 		return C.ulonglong(0), cGoError(err)
@@ -209,7 +207,7 @@ func CloseHTTPTransport(httpTransportID C.ulonglong) {
 }
 
 type HTTPTransport struct {
-	iih      *istio.IstioIntegrationHandler
+	iih      istio.IstioIntegrationHandler
 	client   *http.Client
 	cancel   context.CancelFunc
 	refCount uint32

--- a/pkg/environment/istio.go
+++ b/pkg/environment/istio.go
@@ -23,6 +23,7 @@ import (
 )
 
 type IstioEnvironment struct {
+	Enabled           bool              `env:"ENABLED"`
 	Type              string            `env:"TYPE"`
 	PodName           string            `env:"POD_NAME"`
 	PodNamespace      string            `env:"POD_NAMESPACE"`

--- a/pkg/istio/istio_passthrough_handler.go
+++ b/pkg/istio/istio_passthrough_handler.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       https://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package istio
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"google.golang.org/grpc"
+
+	itcp "github.com/cisco-open/nasp/pkg/istio/tcp"
+)
+
+type passthroughIstioIntegrationHandler struct {
+}
+
+func (h *passthroughIstioIntegrationHandler) GetHTTPTransport(transport http.RoundTripper) (http.RoundTripper, error) {
+	return transport, nil
+}
+
+func (h *passthroughIstioIntegrationHandler) GetTCPListener(l net.Listener) (net.Listener, error) {
+	return l, nil
+}
+
+func (h *passthroughIstioIntegrationHandler) GetTCPDialer() (itcp.Dialer, error) {
+	return &net.Dialer{}, nil
+}
+
+func (h *passthroughIstioIntegrationHandler) ListenAndServe(ctx context.Context, listenAddress string, handler http.Handler) error {
+	return (&http.Server{
+		Addr:    listenAddress,
+		Handler: handler,
+	}).ListenAndServe()
+}
+
+func (h *passthroughIstioIntegrationHandler) GetGRPCDialOptions() ([]grpc.DialOption, error) {
+	return nil, nil
+}
+
+func (h *passthroughIstioIntegrationHandler) Run(context.Context) error {
+	return nil
+}


### PR DESCRIPTION
support Istio handler enabled/disable

- the handler is enabled by the default configuration
- could be disabled by NASP_ENABLED env variable
- passthrough handler is added to handle the disabled case
