### PR TITLE
Make nio nasp zookeeper friendly

### DIFF
--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -20,6 +20,7 @@ import java.nio.channels.spi.AbstractSelector;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -201,10 +201,10 @@ class NaspSelector extends SelectorImpl {
                 if (address != null) {
                     naspSocketChannel.getNaspTcpDialer().startAsyncDial(selectedKeyId, selector,
                             address.getHostString(), address.getPort());
+                    runningAsyncOps.put(selectedKeyId, runningOps | SelectionKey.OP_CONNECT);
                 } else {
                     naspSocketChannel.setSelector(this);
                 }
-                runningAsyncOps.put(selectedKeyId, runningOps | SelectionKey.OP_CONNECT);
             }
         }
     }

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSelectorProvider.java
@@ -47,6 +47,10 @@ class NaspSelector extends SelectorImpl {
         super(sp);
     }
 
+    public nasp.Selector getSelector() {
+        return selector;
+    }
+
     @Override
     protected int doSelect(Consumer<SelectionKey> action, long timeout) throws IOException {
         int to = (int) Math.min(timeout, Integer.MAX_VALUE); // max poll timeout
@@ -193,8 +197,12 @@ class NaspSelector extends SelectorImpl {
             //This could happen if we are servers not clients
             if (naspSocketChannel.getNaspTcpDialer() != null) {
                 InetSocketAddress address = naspSocketChannel.getAddress();
-                naspSocketChannel.getNaspTcpDialer().startAsyncDial(selectedKeyId, selector,
-                        address.getHostString(), address.getPort());
+                if (address != null) {
+                    naspSocketChannel.getNaspTcpDialer().startAsyncDial(selectedKeyId, selector,
+                            address.getHostString(), address.getPort());
+                } else {
+                    naspSocketChannel.setSelector(this);
+                }
                 runningAsyncOps.put(selectedKeyId, runningOps | SelectionKey.OP_CONNECT);
             }
         }

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
@@ -116,8 +116,10 @@ public class NaspServerSocketChannel extends ServerSocketChannel implements SelC
         }
 
         if (((ops & Net.POLLIN) != 0) &&
-                ((intOps & SelectionKey.OP_ACCEPT) != 0))
+                ((intOps & SelectionKey.OP_ACCEPT) != 0)) {
             newOps |= SelectionKey.OP_ACCEPT;
+            System.out.println("INSIDE NET POLLIN OP_ACCEPT");
+        }
 
         ski.nioReadyOps(newOps);
         return (newOps & ~oldOps) != 0;

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspServerSocketChannel.java
@@ -116,10 +116,8 @@ public class NaspServerSocketChannel extends ServerSocketChannel implements SelC
         }
 
         if (((ops & Net.POLLIN) != 0) &&
-                ((intOps & SelectionKey.OP_ACCEPT) != 0)) {
+                ((intOps & SelectionKey.OP_ACCEPT) != 0))
             newOps |= SelectionKey.OP_ACCEPT;
-            System.out.println("INSIDE NET POLLIN OP_ACCEPT");
-        }
 
         ski.nioReadyOps(newOps);
         return (newOps & ~oldOps) != 0;

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocket.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocket.java
@@ -10,7 +10,7 @@ import java.nio.channels.spi.SelectorProvider;
 import nasp.Connection;
 
 public class NaspSocket extends Socket {
-    private final Connection conn;
+    private Connection conn;
     private final SocketChannel channel;
 
     private InetSocketAddress address;
@@ -52,6 +52,15 @@ public class NaspSocket extends Socket {
         }
         return -1;
     }
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return new InetSocketAddress(getInetAddress(), getPort());
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return new InetSocketAddress(getLocalAddress(), getLocalPort());
+    }
 
     @Override
     public InetAddress getInetAddress() {
@@ -88,5 +97,13 @@ public class NaspSocket extends Socket {
     @Override
     public SocketChannel getChannel() {
         return channel;
+    }
+
+    public Connection getConnection () {
+        return conn;
+    }
+
+    public void setConnection (Connection conn) {
+        this.conn = conn;
     }
 }

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
@@ -102,6 +102,7 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
     public boolean connect(SocketAddress remote) throws IOException {
         address = (InetSocketAddress) checkRemote(remote);
         socket.setAddress(address);
+        System.out.println("INSIDE CONNECT");
         if (selector != null) {
             naspTcpDialer.startAsyncDial(this.keyFor(selector).hashCode(), ((NaspSelector)selector).getSelector(),
                     address.getHostString(), address.getPort());
@@ -120,7 +121,8 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
         }
         if (!addr.equals("")) {
             InetSocketAddress almafa = new InetSocketAddress(addr, ((InetSocketAddress) sa).getPort());
-            System.out.println(almafa);
+            System.out.println("HERE COMES THE ADDRESS");
+            System.out.println(almafa + " here we go");
             return almafa;
         }
         System.out.println("JAVAS CHECK REMOTE IS RUNNING!!!");
@@ -155,6 +157,7 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
 
     @Override
     public SocketAddress getRemoteAddress() throws IOException {
+        System.out.println("CALLING GETREMOTE ADDRESS");
         return address;
     }
 
@@ -167,6 +170,7 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
                 return -1;
             }
             dst.put(buff, 0, num);
+//            System.out.println("NUMBER READ BYTES " + num);
             return num;
         } catch (Exception e) {
             throw new IOException(e);
@@ -198,6 +202,7 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
             if (writtenBytes < rem) {
                 src.position(srcBufPos + writtenBytes);
             }
+//            System.out.println("Written bytes are: "+ writtenBytes);
             return writtenBytes;
         } catch (Exception e) {
             throw new IOException(e);

--- a/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
+++ b/experimental/java/examples/nio-java/src/main/java/com/ciscoopen/app/NaspSocketChannel.java
@@ -102,7 +102,6 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
     public boolean connect(SocketAddress remote) throws IOException {
         address = (InetSocketAddress) checkRemote(remote);
         socket.setAddress(address);
-        System.out.println("INSIDE CONNECT");
         if (selector != null) {
             naspTcpDialer.startAsyncDial(this.keyFor(selector).hashCode(), ((NaspSelector)selector).getSelector(),
                     address.getHostString(), address.getPort());
@@ -111,7 +110,6 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
     }
 
     private SocketAddress checkRemote(SocketAddress sa) {
-        System.out.println("GOS CHECK REMOTE IS RUNNING!!!");
         String addr = "";
         try {
             addr = Nasp.checkAddress(
@@ -120,12 +118,8 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
             e.printStackTrace();
         }
         if (!addr.equals("")) {
-            InetSocketAddress almafa = new InetSocketAddress(addr, ((InetSocketAddress) sa).getPort());
-            System.out.println("HERE COMES THE ADDRESS");
-            System.out.println(almafa + " here we go");
-            return almafa;
+            return new InetSocketAddress(addr, ((InetSocketAddress) sa).getPort());
         }
-        System.out.println("JAVAS CHECK REMOTE IS RUNNING!!!");
         InetSocketAddress isa = Net.checkAddress(sa);
         InetAddress address = isa.getAddress();
         if (address.isAnyLocalAddress()) {
@@ -142,13 +136,10 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
 
     @Override
     public boolean finishConnect() throws IOException {
-        System.out.println("INSIDE FINISHCONNECT!!!");
         connection = naspTcpDialer.asyncDial();
         if (connection == null) {
-            System.out.println("INSIDE FINISHCONNECT RETURNING WITH FALSE!!!");
             return false;
         }
-        System.out.println("INSIDE FINISHCONNECT RETURNING WITH TRUE!!!");
         if (socket.getConnection() == null) {
             socket.setConnection(connection);
         }
@@ -157,7 +148,6 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
 
     @Override
     public SocketAddress getRemoteAddress() throws IOException {
-        System.out.println("CALLING GETREMOTE ADDRESS");
         return address;
     }
 
@@ -170,7 +160,6 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
                 return -1;
             }
             dst.put(buff, 0, num);
-//            System.out.println("NUMBER READ BYTES " + num);
             return num;
         } catch (Exception e) {
             throw new IOException(e);
@@ -202,7 +191,6 @@ public class NaspSocketChannel extends SocketChannel implements SelChImpl {
             if (writtenBytes < rem) {
                 src.position(srcBufPos + writtenBytes);
             }
-//            System.out.println("Written bytes are: "+ writtenBytes);
             return writtenBytes;
         } catch (Exception e) {
             throw new IOException(e);

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/pborman/uuid"
 
+	"github.com/cisco-open/nasp/pkg/ads"
 	"github.com/cisco-open/nasp/pkg/istio"
 	itcp "github.com/cisco-open/nasp/pkg/istio/tcp"
 )
@@ -265,6 +266,17 @@ func newNaspIntegrationHandler() *naspIntegrationHandler {
 		ctx:    ctx,
 		cancel: cancel,
 	}
+}
+
+func CheckAddress(address string) (string, error) {
+	ips, err := integrationHandler.iih.GetDiscoveryClient().ResolveHost(address)
+	if err != nil && !errors.Is(err, &ads.HostNotFoundError{HostName: address}) {
+		return "", err
+	}
+	if len(ips) != 0 {
+		return ips[0].String(), nil
+	}
+	return "", nil
 }
 
 func Bind(address string, port int) (*TCPListener, error) {

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -269,7 +269,7 @@ func newNaspIntegrationHandler() *naspIntegrationHandler {
 
 func CheckAddress(address string) (string, error) {
 	ips, err := integrationHandler.iih.GetDiscoveryClient().ResolveHost(address)
-	if err != nil && !errors.Is(err, &ads.HostNotFoundError{HostName: address}) {
+	if ads.IgnoreHostNotFound(err) != nil {
 		return "", err
 	}
 	if len(ips) != 0 {

--- a/experimental/java/main.go
+++ b/experimental/java/main.go
@@ -70,9 +70,8 @@ func Setup(logLevel int) {
 type TCPListener struct {
 	listener net.Listener
 
-	asyncConnectionsLock sync.Mutex
-	asyncConnections     []*Connection
-	terminated           atomic.Bool
+	asyncConnection chan *Connection
+	terminated      atomic.Bool
 
 	acceptInProgress atomic.Bool
 
@@ -291,8 +290,9 @@ func Bind(address string, port int) (*TCPListener, error) {
 	}
 
 	return &TCPListener{
-		listener: listener,
-		logger:   logger.WithName("TCPListener"),
+		listener:        listener,
+		logger:          logger.WithName("TCPListener"),
+		asyncConnection: make(chan *Connection, 1),
 	}, nil
 }
 
@@ -342,10 +342,7 @@ func (l *TCPListener) StartAsyncAccept(selectedKeyId int32, selector *Selector) 
 				println(err.Error())
 				continue
 			}
-
-			l.asyncConnectionsLock.Lock()
-			l.asyncConnections = append(l.asyncConnections, conn)
-			l.asyncConnectionsLock.Unlock()
+			l.asyncConnection <- conn
 
 			selector.queue <- NewSelectedKey(OP_ACCEPT, uint32(selectedKeyId))
 		}
@@ -353,16 +350,8 @@ func (l *TCPListener) StartAsyncAccept(selectedKeyId int32, selector *Selector) 
 }
 
 func (l *TCPListener) AsyncAccept() *Connection {
-	l.asyncConnectionsLock.Lock()
-	defer l.asyncConnectionsLock.Unlock()
-
-	if len(l.asyncConnections) > 0 {
-		conn := l.asyncConnections[0]
-		l.asyncConnections = l.asyncConnections[1:]
-		return conn
-	}
-
-	return nil
+	conn := <-l.asyncConnection
+	return conn
 }
 
 func (c *Connection) GetAddress() (*Address, error) {
@@ -407,7 +396,8 @@ func (c *Connection) StartAsyncRead(selectedKeyId int32, selector *Selector) {
 		for {
 			num, err := c.Read(tempBuffer)
 			if err != nil {
-				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.ECONNRESET) {
+				if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) ||
+					errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
 					c.setEofReceived()
 					selector.readInProgress.Store(selectedKeyId, false)
 					break

--- a/pkg/ads/api.go
+++ b/pkg/ads/api.go
@@ -83,6 +83,8 @@ type Client interface {
 	// DecrementActiveRequestsCount decrements the active requests count for the endpoint given its address
 	// Should be invoked when the endpoint finished processing a request
 	DecrementActiveRequestsCount(address string)
+
+	ResolveHost(hostName string) ([]net.IP, error)
 }
 
 // ListenerPropertiesResponse contains the result for the API call

--- a/pkg/ads/api_http_client.go
+++ b/pkg/ads/api_http_client.go
@@ -168,7 +168,7 @@ func (c *client) getHTTPClientPropertiesByHost(input getHTTPClientPropertiesByHo
 // getHttpClientTargetCluster returns the upstream cluster which HTTP traffic is directed to when
 // clients connect to host:port
 func (c *client) getHttpClientTargetCluster(host string, port int) (*envoy_config_cluster_v3.Cluster, *envoy_config_route_v3.Route, error) {
-	hostIPs, err := c.resolveHost(host)
+	hostIPs, err := c.ResolveHost(host)
 	if err != nil {
 		return nil, nil, errors.WrapIff(err, "couldn't resolve host %q", host)
 	}

--- a/pkg/ads/api_tcp_client.go
+++ b/pkg/ads/api_tcp_client.go
@@ -212,7 +212,7 @@ func (c *client) getTCPClientPropertiesByHost(input getTCPClientPropertiesByHost
 // getTCPClientTargetCluster returns the Envoy upstream cluster which TCP traffic is directed to when
 // clients connect to host:port
 func (c *client) getTCPClientTargetCluster(host string, port int) (*envoy_config_cluster_v3.Cluster, error) {
-	hostIPs, err := c.resolveHost(host)
+	hostIPs, err := c.ResolveHost(host)
 	if err != nil {
 		return nil, errors.WrapIff(err, "couldn't resolve host %q", host)
 	}

--- a/pkg/ads/nametable.go
+++ b/pkg/ads/nametable.go
@@ -26,7 +26,7 @@ import (
 
 // resolveHostName resolves the provides host name to IP addresses using
 // Istio's NDS
-func (c *client) resolveHost(hostName string) ([]net.IP, error) {
+func (c *client) ResolveHost(hostName string) ([]net.IP, error) {
 	var hostIPs []net.IP
 	hostIP := net.ParseIP(hostName)
 

--- a/pkg/istio/discovery/api.go
+++ b/pkg/istio/discovery/api.go
@@ -30,6 +30,7 @@ type DiscoveryClient interface {
 	NewConnectionCloseWrapper() ConnectionCloseWrapper
 	NewDialWrapper() DialWrapper
 	Logger() logr.Logger
+	ResolveHost(hostName string) ([]net.IP, error)
 }
 
 type ClientDiscoveryClient interface {

--- a/pkg/istio/discovery/xds.go
+++ b/pkg/istio/discovery/xds.go
@@ -73,6 +73,10 @@ func NewXDSDiscoveryClient(environment *environment.IstioEnvironment, caClient c
 	}
 }
 
+func (d *xdsDiscoveryClient) ResolveHost(hostName string) ([]net.IP, error) {
+	return d.xdsClient.ResolveHost(hostName)
+}
+
 func (d *xdsDiscoveryClient) Connect(ctx context.Context) error {
 	ctx = logr.NewContext(ctx, d.logger)
 

--- a/pkg/istio/istio.go
+++ b/pkg/istio/istio.go
@@ -181,6 +181,7 @@ type IstioIntegrationHandler interface {
 	GetHTTPTransport(transport http.RoundTripper) (http.RoundTripper, error)
 	GetTCPListener(l net.Listener) (net.Listener, error)
 	GetTCPDialer() (itcp.Dialer, error)
+	GetDiscoveryClient() discovery.DiscoveryClient
 }
 
 func NewIstioIntegrationHandler(config *IstioIntegrationHandlerConfig, logger logr.Logger) (IstioIntegrationHandler, error) {
@@ -277,6 +278,10 @@ func NewIstioIntegrationHandler(config *IstioIntegrationHandlerConfig, logger lo
 	}
 
 	return s, nil
+}
+
+func (h *istioIntegrationHandler) GetDiscoveryClient() discovery.DiscoveryClient {
+	return h.discoveryClient
 }
 
 func (h *istioIntegrationHandler) NewStreamHandler(filters ...api.WasmPluginConfig) (api.StreamHandler, error) {

--- a/pkg/istio/istio_passthrough_handler.go
+++ b/pkg/istio/istio_passthrough_handler.go
@@ -21,8 +21,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	itcp "github.com/cisco-open/nasp/pkg/istio/tcp"
 	"github.com/cisco-open/nasp/pkg/istio/discovery"
+	itcp "github.com/cisco-open/nasp/pkg/istio/tcp"
 )
 
 type passthroughIstioIntegrationHandler struct {

--- a/pkg/istio/istio_passthrough_handler.go
+++ b/pkg/istio/istio_passthrough_handler.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 
 	itcp "github.com/cisco-open/nasp/pkg/istio/tcp"
+	"github.com/cisco-open/nasp/pkg/istio/discovery"
 )
 
 type passthroughIstioIntegrationHandler struct {
@@ -44,6 +45,10 @@ func (h *passthroughIstioIntegrationHandler) ListenAndServe(ctx context.Context,
 		Addr:    listenAddress,
 		Handler: handler,
 	}).ListenAndServe()
+}
+
+func (h *passthroughIstioIntegrationHandler) GetDiscoveryClient() discovery.DiscoveryClient {
+	return nil
 }
 
 func (h *passthroughIstioIntegrationHandler) GetGRPCDialOptions() ([]grpc.DialOption, error) {

--- a/pkg/istio/tcp/dialer.go
+++ b/pkg/istio/tcp/dialer.go
@@ -17,7 +17,6 @@ package istio
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 
 	"github.com/cisco-open/nasp/pkg/istio/discovery"
@@ -56,10 +55,9 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 
 	prop, err := d.discoveryClient.GetTCPClientPropertiesByHost(context.Background(), address)
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
 
-	fmt.Printf("Prop: %#v\n", prop)
 	if prop != nil {
 		if !prop.UseTLS() {
 			tlsConfig = nil
@@ -70,13 +68,10 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 			return nil, err
 		} else {
 			address = endpointAddr.String()
-			fmt.Printf("address: %s\n", address)
 		}
 	}
 
 	useTLS := tlsConfig != nil
-
-	fmt.Printf("Use tls: %#v\n", useTLS)
 
 	opts := []network.DialerOption{
 		network.DialerWithWrappedConnectionOptions(network.WrappedConnectionWithCloserWrapper(d.discoveryClient.NewConnectionCloseWrapper())),

--- a/pkg/istio/tcp/dialer.go
+++ b/pkg/istio/tcp/dialer.go
@@ -17,6 +17,7 @@ package istio
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 
 	"github.com/cisco-open/nasp/pkg/istio/discovery"
@@ -54,6 +55,7 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 	tlsConfig := d.tlsConfig.Clone()
 
 	prop, _ := d.discoveryClient.GetTCPClientPropertiesByHost(context.Background(), address)
+	fmt.Printf("%#v\n", prop)
 	if prop != nil {
 		if !prop.UseTLS() {
 			tlsConfig = nil
@@ -64,6 +66,7 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 			return nil, err
 		} else {
 			address = endpointAddr.String()
+			fmt.Printf("%s\n", address)
 		}
 	}
 
@@ -85,11 +88,7 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 		var conn net.Conn
 		var err error
 
-		if useTLS {
-			conn, err = connectionDialer.DialContext(ctx, _net, address)
-		} else {
-			conn, err = connectionDialer.DialTLSContext(ctx, _net, address)
-		}
+		conn, err = connectionDialer.DialContext(ctx, _net, address)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/istio/tcp/dialer.go
+++ b/pkg/istio/tcp/dialer.go
@@ -54,8 +54,12 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 
 	tlsConfig := d.tlsConfig.Clone()
 
-	prop, _ := d.discoveryClient.GetTCPClientPropertiesByHost(context.Background(), address)
-	fmt.Printf("%#v\n", prop)
+	prop, err := d.discoveryClient.GetTCPClientPropertiesByHost(context.Background(), address)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Printf("Prop: %#v\n", prop)
 	if prop != nil {
 		if !prop.UseTLS() {
 			tlsConfig = nil
@@ -66,11 +70,13 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 			return nil, err
 		} else {
 			address = endpointAddr.String()
-			fmt.Printf("%s\n", address)
+			fmt.Printf("address: %s\n", address)
 		}
 	}
 
 	useTLS := tlsConfig != nil
+
+	fmt.Printf("Use tls: %#v\n", useTLS)
 
 	opts := []network.DialerOption{
 		network.DialerWithWrappedConnectionOptions(network.WrappedConnectionWithCloserWrapper(d.discoveryClient.NewConnectionCloseWrapper())),
@@ -116,7 +122,7 @@ func (d *tcpDialer) DialContext(ctx context.Context, _net string, address string
 		d.connectionPoolRegistry.AddPool(address, p)
 	}
 
-	cp, err := d.connectionPoolRegistry.GetPool(address)
+	cp, err = d.connectionPoolRegistry.GetPool(address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Implements a couple of functions that were needed for the zookeeper client inside Kafka.
It contains a couple of bug fixes regarding accepting a connection.
Propagating DiscoveryClient to query the proper address of the instance.

## Type of Change

- [X] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
