### PR TITLE
rust: make rust projects vscode loadable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,7 @@ testbin/*
 experimental/wasm-tcp-metadata/target
 experimental/wasm-tcp-metadata/Cargo.lock
 experimental/wasm-tcp-metadata/debug
+target/
+Cargo.lock
 
 .java-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "./experimental/wasm-tcp-metadata",
+]


### PR DESCRIPTION
## Description

This way `rust-analyzer` just works when opening the project in VSCode.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

