### PR TITLE
wasm-tcp-metadata: tune release profile to be wasm3 friendly

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -45,6 +45,10 @@ jobs:
         id: set-git-refname
         run: echo "git_refname=$(echo "${{ github.ref }}" | sed -r 's@refs/(heads|pull|tags)/@@g')" >> $GITHUB_OUTPUT
 
+      - name: Build TCP metadata exchange filter
+        run: |
+          make tcp-metadata-exchange-filter
+
       - name: Deploy to kind cluster (istio-operator)
         run: |
           test/deploy-kind.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,10 @@ jobs:
           restore-keys: |
             build-deps-v2
 
+      - name: Build TCP metadata exchange filter
+        run: |
+          make tcp-metadata-exchange-filter
+
       - name: Run unit tests
         run: make test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,13 @@
 members = [
     "./experimental/wasm-tcp-metadata",
 ]
+
+[profile.release]
+# do not include debug symbols
+debug = false
+# link-time optimalization
+lto = 'thin' # this works much better for wasm3 than 'true'
+# optimize for binary size for wasm s is better than z
+opt-level = "s"
+# do not unwind the stack when panicking
+#panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,9 @@ lint-fix-all: ${REPO_ROOT}/bin/golangci-lint ## lint --fix the whole repo
 .PHONY: mod-download-all
 mod-download-all:	## go mod download all go modules
 	./scripts/for_all_go_modules.sh -- go mod download all
+
+.PHONY: tcp-metadata-exchange-filter
+tcp-metadata-exchange-filter:	## build the tcp-metadata-exchange-filter
+	rustup target add wasm32-unknown-unknown
+	cargo build --target wasm32-unknown-unknown --release
+	cp target/wasm32-unknown-unknown/release/wasm_tcp_metadata.wasm pkg/istio/filters/tcp-metadata-exchange-filter.wasm

--- a/experimental/wasm-tcp-metadata/Cargo.toml
+++ b/experimental/wasm-tcp-metadata/Cargo.toml
@@ -8,16 +8,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[profile.release]
-# do not include debug symbols
-debug = false
-# link-time optimalization
-lto = true
-# optimize for binary size for wasm s is better than z
-opt-level = "s"
-# do not unwind the stack when panicking
-panic = "abort"
-
 [dependencies]
 proxy-wasm = "0.2.1"
 log = "0.4"


### PR DESCRIPTION
## Description

Few lines of cange, which cost a few days of headaches, but now the filter is Wasm3 friendly, at least until (and including) `proxy_on_configure`. Otherwise it hangs forever. The main change is that LTO works only on the `thin` level for Wasm3: https://doc.rust-lang.org/cargo/reference/profiles.html#lto

The size reduction we get with these flags is fairly enough for now.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
