### PR TITLE
Reduce the number of heap allocations in wrappedConn and connectionStateTracker

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -180,9 +180,7 @@ func (c *connection) setTLSConnectionState() {
 		return
 	}
 
-	t := &connectionStateTracker{
-		logger: ConnectionStateTrackerLogger,
-	}
+	t := &connectionStateTracker{}
 
 	tlsConn := t.getTLSConnection(c)
 	if tlsConn != nil {

--- a/pkg/network/connection_state_tracker.go
+++ b/pkg/network/connection_state_tracker.go
@@ -21,19 +21,16 @@ import (
 	"github.com/go-logr/logr"
 )
 
-var ConnectionStateTrackerLogger logr.Logger = logr.Discard()
+var discardLogger = logr.Discard()
+var ConnectionStateTrackerLogger logr.Logger = discardLogger
 
 type connectionStateTracker struct {
-	logger logr.Logger
-
 	connectionState            ConnectionState
 	connWithTLSConnectionState ConnWithTLSConnectionState
 }
 
 func ConnectionStateFromNetConn(conn net.Conn) (ConnectionState, bool) {
-	t := &connectionStateTracker{
-		logger: ConnectionStateTrackerLogger,
-	}
+	t := &connectionStateTracker{}
 
 	state := t.getConnectionState(conn)
 
@@ -45,7 +42,9 @@ func ConnectionStateFromNetConn(conn net.Conn) (ConnectionState, bool) {
 }
 
 func (t *connectionStateTracker) getTLSConnection(c net.Conn) net.Conn {
-	t.logger.Info("check connection", "type", fmt.Sprintf("%T", c))
+	if ConnectionStateTrackerLogger != discardLogger {
+		ConnectionStateTrackerLogger.Info("check connection", "type", fmt.Sprintf("%T", c))
+	}
 
 	if _, ok := c.(ConnWithTLSConnectionState); ok {
 		return c
@@ -65,7 +64,9 @@ func (t *connectionStateTracker) getTLSConnection(c net.Conn) net.Conn {
 }
 
 func (t *connectionStateTracker) getConnectionState(c net.Conn) ConnectionState {
-	t.logger.Info("check connection", "type", fmt.Sprintf("%T", c))
+	if ConnectionStateTrackerLogger != discardLogger {
+		ConnectionStateTrackerLogger.Info("check connection", "type", fmt.Sprintf("%T", c))
+	}
 
 	if c, ok := c.(ConnWithTLSConnectionState); ok {
 		t.connWithTLSConnectionState = c

--- a/pkg/proxywasm/host.go
+++ b/pkg/proxywasm/host.go
@@ -31,7 +31,8 @@ import (
 type HostFunctions struct {
 	pwapi.ImportsHandler
 
-	logger logr.Logger
+	logger           logr.Logger
+	wasmFilterLogger logr.Logger
 
 	properties api.PropertyHolder
 	metrics    api.MetricHandler
@@ -42,6 +43,7 @@ type HostFunctionsOption func(hf *HostFunctions)
 func SetHostFunctionsLogger(logger logr.Logger) HostFunctionsOption {
 	return func(hf *HostFunctions) {
 		hf.logger = logger
+		hf.wasmFilterLogger = hf.logger.WithName("wasm filter")
 	}
 }
 
@@ -64,6 +66,7 @@ func NewHostFunctions(properties api.PropertyHolder, options ...HostFunctionsOpt
 
 	if hf.logger == (logr.Logger{}) {
 		hf.logger = klog.Background()
+		hf.wasmFilterLogger = hf.logger.WithName("wasm filter")
 	}
 
 	return hf
@@ -91,7 +94,7 @@ func (f *HostFunctions) Log(level pwapi.LogLevel, msg string) pwapi.WasmResult {
 		logLevel = 2 - int(level)
 	}
 
-	f.Logger().V(logLevel).WithName("wasm filter").Info(msg, "level", level)
+	f.wasmFilterLogger.V(logLevel).Info(msg, "level", level)
 
 	return pwapi.WasmResultOk
 }


### PR DESCRIPTION
Reduce the number of heap allocations in wrappedConn and connectionStateTracker to enhance performance.

