### PR TITLE
Fix RecordBatch parsing

### DIFF
--- a/components/kafka-protocol-go/pkg/protocol/types/bytes/chunkreader.go
+++ b/components/kafka-protocol-go/pkg/protocol/types/bytes/chunkreader.go
@@ -238,9 +238,9 @@ func (c *ChunkReader) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		abs = c.size + offset
 		if c.cr != nil {
-			rebasedOffset = c.size - c.cr.Size() + offset
+			rebasedOffset = c.base + c.size - c.cr.Size() + offset
 		} else {
-			rebasedOffset = c.size - c.br.Size() + offset
+			rebasedOffset = c.base + c.size - c.br.Size() + offset
 		}
 	default:
 		return 0, errors.New("bytes.ChunkReader.Seek: invalid whence")

--- a/components/kafka-protocol-go/pkg/protocol/types/fields/recordbatches.go
+++ b/components/kafka-protocol-go/pkg/protocol/types/fields/recordbatches.go
@@ -17,6 +17,7 @@ package fields
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"strconv"
 	"strings"
 
@@ -128,15 +129,14 @@ func (b *RecordBatches) Read(r *typesbytes.ChunkReader) error {
 		if batchSize == 0 || r.Len() < batchSize {
 			// if next batch's size is zero or r has fewer bytes remaining the batchSize
 			// than we already processed the last complete record batch
+			if r.Len() < batchSize {
+				_, err = r.Seek(0, io.SeekEnd)
+				if err != nil {
+					return err
+				}
+			}
 			b.Complete()
 			return nil
-		}
-
-		if r.Len() < batchSize {
-			return errors.WrapIf(err, strings.Join([]string{"expected", strconv.Itoa(batchSize), "record batch bytes for item", strconv.Itoa(i), "but only got", strconv.Itoa(r.Len())}, " "))
-		}
-		if r.Len() < batchSize {
-			batchSize = r.Len()
 		}
 
 		var rb RecordBatch


### PR DESCRIPTION
## Description

- Fix: ChunkReader.Seek not working properly when the seek is relative to the end.
- Fix: In case of incomplete record batch move the reader's pointer to the end of byte slice

## Type of Change

- [x] Bug Fix

